### PR TITLE
Decimal places

### DIFF
--- a/src/components/AccountBalance.js
+++ b/src/components/AccountBalance.js
@@ -4,10 +4,11 @@ class AccountBalance extends Component {
   render() {
     return (
         <div>
-          Balance: {this.props.accountBalance}
+          Balance: {Math.round(this.props.accountBalance*100)/100}
+
         </div>
     );
   }
 }
-
+/////{Math.round((this.props.accountBalance*100)/100).toFixed(2)}
 export default AccountBalance;


### PR DESCRIPTION
This ensures that the account balance goes to two decimal places only. As a bank we are dealing with money and can go only as small as 1 cent as far as users are concerned. Account balance should reflect that now